### PR TITLE
Monkeypatched attrdict to work in python 3.10+.

### DIFF
--- a/crawl.py
+++ b/crawl.py
@@ -1,6 +1,17 @@
 #!/usr/bin/env python3
 
-from attrdict import AttrDict
+# NOTE: attrdict broken in python 3.10 and not maintained.
+# https://github.com/wallento/wavedrompy/issues/32#issuecomment-1306701776
+try:
+    from attrdict import AttrDict
+except ImportError:
+    # Monkey patch collections
+    import collections
+    import collections.abc
+    for type_name in collections.abc.__all__:
+        setattr(collections, type_name, getattr(collections.abc, type_name))
+    from attrdict import AttrDict
+
 import mechanicalsoup
 import json
 


### PR DESCRIPTION
attrdict doesn't work in python 3.10+. To get it working without having to force a lower version if python I sligthly modified the patch below and patched it in.

NOTE: This is NOT a clean solution, it's just a patch to get it working. You might want to do a cleaner solution later on or even not include this patch, I created the PR for you if you want to use it, but if you don't want to add the dirty solution and instead force lower versions of python until a good fix it's fine.

The code is from the following commit and only slightly modified to get it working in this case. https://github.com/triton-inference-server/client/pull/319/commits/be51ef452bfc87d066282dfe92e24123da18cf36